### PR TITLE
Add Linux kernel mirror

### DIFF
--- a/scripts/download.pl
+++ b/scripts/download.pl
@@ -198,6 +198,7 @@ foreach my $mirror (@ARGV) {
 #push @mirrors, 'http://mirror1.openwrt.org';
 push @mirrors, 'http://mirror2.openwrt.org/sources';
 push @mirrors, 'http://downloads.openwrt.org/sources';
+push @mirrors, 'https://www.kernel.org/pub/linux/kernel/v3.x/';
 
 while (!$ok) {
 	my $mirror = shift @mirrors;


### PR DESCRIPTION
The making process fails due to shutting down of linux kernel ftp services
https://www.kernel.org/shutting-down-ftp-services.html. This commit adds a
working mirror